### PR TITLE
Make mysql, redis, varnish, and nfs listen on only backnet

### DIFF
--- a/playbooks/group_vars/db.yml
+++ b/playbooks/group_vars/db.yml
@@ -18,6 +18,8 @@ mysql_databases: "{{ nex_app_db_info|default([]) }}"
 
 mysql_users: "{{ nex_app_db_user_info|default([]) }}"
 
+mysql_bind_address: "{{ backnet_addr }}"
+
 firewall_v4_group_rules:
   401 allow backnet mysql traffic from PHP servers:
     - "-A INPUT -p tcp --dport 3306 -j ACCEPT -s {{ fpm_backnet_addrs | join(',') }} -d {{ backnet_addr }}"

--- a/playbooks/group_vars/fs.yml
+++ b/playbooks/group_vars/fs.yml
@@ -21,6 +21,10 @@ nfs_ports:
   - {name: STATD_PORT,          value: "{{ nfs_STATD_PORT }}" }
   - {name: STATD_OUTGOING_PORT, value: "{{ nfs_STATD_OUTGOING_PORT }}" }
 
+rpc_nfsd_args:  "-H {{ backnet_addr }}"
+rpc_statd_args: "-n {{ backnet_addr }}"
+rpc_bind_args:  "-h {{ backnet_addr }}"
+
 firewall_v4_group_rules:
   401 allow portmap ports:
     - "-A INPUT -m state --state NEW -p tcp --dport 111 -j ACCEPT"

--- a/playbooks/group_vars/redis.yml
+++ b/playbooks/group_vars/redis.yml
@@ -2,6 +2,8 @@
 
 server_role: "redis"
 
+redis_bind: "{{ backnet_addr }}"
+
 firewall_v4_group_rules:
   401 allow backnet redis traffic:
     - "-A INPUT -p tcp --dport {{ redis_port }} -j ACCEPT -s {{ lb_redis_backnet_addrs | join(',') }} -d {{ backnet_addr }}"

--- a/playbooks/group_vars/varnish.yml
+++ b/playbooks/group_vars/varnish.yml
@@ -2,6 +2,7 @@
 
 server_role: "varnish"
 
+varnish_listen_address: "{{ backnet_addr }}"
 varnish_listen_port: "{{ varnish_port }}"
 varnish_default_backend_host: "{{ lb_web_backnet_addrs[0] }}"
 varnish_default_backend_port: "{{ web_port }}"


### PR DESCRIPTION
NFS to some extent anyway.  rpc.statd seems to still bind
to 0.0.0.0, as does systemd port 111 on behalf of rpcbind.
Fought it for a while, may revisit.